### PR TITLE
Spring cleaning!

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,11 @@
 import sbtrelease.ReleaseStateTransformations._
 
+val scala_2_12: String = "2.12.11"
+val scala_2_13: String = "2.13.2"
+
 lazy val publishSettings = Seq(
+  crossScalaVersions := Seq(scala_2_12, scala_2_13),
+  releaseCrossBuild := true,
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   bintrayOrganization := Some("guardian"),
   bintrayRepository := "platforms",
@@ -25,12 +30,14 @@ lazy val root = (project in file("."))
   .settings(
     licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html")),
     organization := "com.gu",
-    scalaVersion := "2.12.7",
+    scalaVersion := scala_2_12,
     name := "mobile-logstash-encoder",
     libraryDependencies ++= Seq(
-      "com.gu" %% "simple-configuration-core" % "1.5.0",
+      "com.gu" %% "simple-configuration-core" % "1.5.2",
       "net.logstash.logback" % "logstash-logback-encoder" % "5.2",
       "ch.qos.logback" % "logback-core" % "1.2.3",
-      "com.typesafe.play" %% "play-json" % "2.6.10"
+      "com.fasterxml.jackson.core" % "jackson-core" % "2.9.10",
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10.4",
+      "org.specs2" %% "specs2-core" % "4.8.3" % "test"
     )
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.6
+sbt.version=1.3.10

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.10")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2-1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")

--- a/src/main/scala/com/gu/mobile/logback/MobileLogstashEncoder.scala
+++ b/src/main/scala/com/gu/mobile/logback/MobileLogstashEncoder.scala
@@ -1,43 +1,82 @@
 package com.gu.mobile.logback
 
+import java.io.StringWriter
+
 import com.amazonaws.util.EC2MetadataUtils
+import com.fasterxml.jackson.core.{JsonFactory, TreeNode}
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
 import com.gu.{AppIdentity, AwsIdentity}
 import net.logstash.logback.encoder.LogstashEncoder
-import play.api.libs.json.{JsObject, JsString, Json}
 
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
-final class MobileLogstashEncoder extends LogstashEncoder {
+trait JsonConcatenationLogic {
+
+  private val mapper = new ObjectMapper()
+  private val jsonFactory = new JsonFactory(mapper)
+
+  def concatenateEnvToCustomFields(customFields: String, extraFields: Map[String, String]): String = {
+    def parsedTreeNode: Try[TreeNode] = {
+      if (customFields != null && customFields.trim != "") {
+        Try(jsonFactory.createParser(customFields).readValueAsTree[TreeNode]())
+      } else {
+        Success(mapper.createObjectNode())
+      }
+    }
+
+    def appendToObjectNode(treeNode: TreeNode): Try[ObjectNode] = treeNode match {
+      case objectNode: ObjectNode => {
+        extraFields.foreach { case (key, value) => objectNode.put(key, value) }
+        Success(objectNode)
+      }
+      case _ => Failure(new RuntimeException(s"Parsed Json was not an object: ${customFields}"))
+    }
+
+    def serialiseToString(objectNode: ObjectNode): Try[String] = Try {
+      val sw = new StringWriter()
+      val generator = jsonFactory.createGenerator(sw)
+      generator.writeTree(objectNode)
+      sw.toString
+    }
+
+    val concatenatedFields = for {
+      treeNode <- parsedTreeNode
+      objectNode <- appendToObjectNode(treeNode)
+      output <- serialiseToString(objectNode)
+    } yield output
+
+    concatenatedFields match {
+      case Success(result) => result
+      case Failure(exception) => throw exception
+    }
+  }
+}
+
+final class MobileLogstashEncoder extends LogstashEncoder with JsonConcatenationLogic {
   private var maybeDefaultAppName: Option[String] = None
 
   def setDefaultAppName(defaultAppName: String): Unit = maybeDefaultAppName = Some(defaultAppName)
 
-  private lazy val loadAppStackStageJsObject: JsObject = {
+  private lazy val loadAppStackStage: Map[String, String] = {
     val defaultAppName: String = maybeDefaultAppName.getOrElse(throw new IllegalArgumentException(
       s"""Logback xml must include a defaultAppName like
          |<encoder class="${classOf[MobileLogstashEncoder].getCanonicalName}">
          |  <defaultAppName>APP_NAME_HERE</defaultAppName>
          |</encoder>
       """.stripMargin))
-    JsObject(((AppIdentity.whoAmI(defaultAppName = defaultAppName) match {
+    (AppIdentity.whoAmI(defaultAppName = defaultAppName) match {
       case awsIdentity: AwsIdentity => Map(
         "app" -> awsIdentity.app,
         "stack" -> awsIdentity.stack,
         "stage" -> awsIdentity.stage
       )
       case _ => Map("app" -> defaultAppName)
-    }) ++ Option(EC2MetadataUtils.getInstanceId).map("ec2_instance" -> _)).mapValues(JsString))
+    }) ++ Option(EC2MetadataUtils.getInstanceId).map("ec2_instance" -> _)
   }
 
   override def start(): Unit = {
-    this.setCustomFields(Json.stringify(getCustomFieldsAsPlayJsObject.deepMerge(loadAppStackStageJsObject)))
+    this.setCustomFields(concatenateEnvToCustomFields(this.getCustomFields, loadAppStackStage))
     super.start()
   }
-
-  private def getCustomFieldsAsPlayJsObject = Try(Json.parse(getCustomFields))
-    .map(_.validate[JsObject].asOpt)
-    .toOption
-    .flatten
-    .getOrElse(JsObject(Seq()))
-
 }

--- a/src/test/scala/com/gu/mobile/logback/JsonConcatenationLogicSpec.scala
+++ b/src/test/scala/com/gu/mobile/logback/JsonConcatenationLogicSpec.scala
@@ -21,5 +21,11 @@ class JsonConcatenationLogicSpec extends Specification with Matchers {
       val expected = "{\"Custom1\":\"Field1\",\"Custom2\":\"Field2\",\"Extra3\":\"Field3\",\"Extra4\":\"Field4\"}"
       logic.concatenateEnvToCustomFields(customFields, extraFields) shouldEqual expected
     }
+    "Concatenate fields with a nested structure" in {
+      val customFields = "{\"Custom1\":\"Field1\",\"Custom2\":{\"Custom3\":\"Field3\",\"Custom4\":\"Field4\"}}"
+      val extraFields = Map("Extra3" -> "Field3", "Extra4" -> "Field4")
+      val expected = "{\"Custom1\":\"Field1\",\"Custom2\":{\"Custom3\":\"Field3\",\"Custom4\":\"Field4\"},\"Extra3\":\"Field3\",\"Extra4\":\"Field4\"}"
+      logic.concatenateEnvToCustomFields(customFields, extraFields) shouldEqual expected
+    }
   }
 }

--- a/src/test/scala/com/gu/mobile/logback/JsonConcatenationLogicSpec.scala
+++ b/src/test/scala/com/gu/mobile/logback/JsonConcatenationLogicSpec.scala
@@ -1,0 +1,25 @@
+package com.gu.mobile.logback
+
+import org.specs2.matcher.Matchers
+import org.specs2.mutable.Specification
+
+class JsonConcatenationLogicSpec extends Specification with Matchers {
+  "The concatenation logic" should {
+    val logic = new JsonConcatenationLogic {}
+    "Gracefully handle and empty customFields" in {
+      logic.concatenateEnvToCustomFields("", Map()) shouldEqual "{}"
+    }
+    "Concatenate fields to an empty custom fields" in {
+      val customFields = ""
+      val extraFields = Map("Extra" -> "Field")
+      val expected = "{\"Extra\":\"Field\"}"
+      logic.concatenateEnvToCustomFields(customFields, extraFields) shouldEqual expected
+    }
+    "Concatenate fields" in {
+      val customFields = "{\"Custom1\":\"Field1\",\"Custom2\":\"Field2\"}"
+      val extraFields = Map("Extra3" -> "Field3", "Extra4" -> "Field4")
+      val expected = "{\"Custom1\":\"Field1\",\"Custom2\":\"Field2\",\"Extra3\":\"Field3\",\"Extra4\":\"Field4\"}"
+      logic.concatenateEnvToCustomFields(customFields, extraFields) shouldEqual expected
+    }
+  }
+}


### PR DESCRIPTION
 - Upgrade Scala version
 - Upgrade SBT version
 - Upgrade Release pipeline version
 - Cross publish to scala 2.13
 - Drop dependency on Play, use Jackson directly
 - Add a unit test to check the serialisation logic


The implementation with Jackson is slightly longer and more verbose but avoids having this (very) low level package depend on Play