### PR TITLE
Handles error obtaining EC2 instance id when running in non-AWS env

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.7
+sbt.version=1.6.0-RC2

--- a/src/main/scala/com/gu/mobile/logback/MobileLogstashEncoder.scala
+++ b/src/main/scala/com/gu/mobile/logback/MobileLogstashEncoder.scala
@@ -72,7 +72,7 @@ final class MobileLogstashEncoder extends LogstashEncoder with JsonConcatenation
         "stage" -> awsIdentity.stage
       )
       case _ => Map("app" -> defaultAppName)
-    }) ++ Option(EC2MetadataUtils.getInstanceId).map("ec2_instance" -> _)
+    }) ++ Try(EC2MetadataUtils.getInstanceId).toOption.map("ec2_instance" -> _)
   }
 
   override def start(): Unit = {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.6"
+version in ThisBuild := "1.1.7-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.1.3-SNAPSHOT"
+ThisBuild / version := "1.1.6-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.1.6-SNAPSHOT"
+version in ThisBuild := "1.1.6"


### PR DESCRIPTION
## What does this change?

Obtaining `EC2MetadataUtils.getInstanceId` is now wrapped in `Try`. This should handle the error encountered at startup of client applications of this library when run in non-AWS environment (e.g. development machines)

Version jumped up to `1.1.6-SNAPSHOT` as version `1.1.5` [already exists](https://repo1.maven.org/maven2/com/gu/mobile-logstash-encoder_2.13/).

SBT version upgrade.

## How to test

- Once this pull request is merged, implement the `release` process to release version `1.1.6`.
- Update client application (e.g. MAPI) to use released version `1.1.6`. Run client application locally.  There should be no error in setting up of `MobileLogstashEncoder`.
- Deploy client application in CODE. Application logs should continue to include EC2 instance ID.


