### PR TITLE
LIVE-5891 Bump simple configuration to 1.5.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ lazy val root = (project in file("."))
     scalaVersion := scala_2_12,
     name := "mobile-logstash-encoder",
     libraryDependencies ++= Seq(
-      "com.gu" %% "simple-configuration-core" % "1.5.5",
+      "com.gu" %% "simple-configuration-core" % "1.5.7",
       "net.logstash.logback" % "logstash-logback-encoder" % "5.2",
       "ch.qos.logback" % "logback-core" % "1.2.7",
       "com.fasterxml.jackson.core" % "jackson-core" % "2.9.10",

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.7"
+version in ThisBuild := "1.1.8-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.7-SNAPSHOT"
+version in ThisBuild := "1.1.7"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We want to bump the `simple-configuration` library used in MAPI to a newer version from 1.5.6, and code changes are required due to API change.  As the `mobile-logstash-encoder` also depends on `simple-configuration` to collect the custom fields about `app`, `stage` and `stack`, we have to make the same changes here.

For details on the code changes, please refer to guardian/mobile-apps-api#2797 

## How to test

The bundle was published locally as version 1.1.7-SNAPSHOT and the MAPI was changed to use this snapshot version.  The service was deployed locally and it worked successfully.  Logs were also created.
