### PR TITLE
Fix netty snyk vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,6 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Seq(
       "software.amazon.awssdk" % "autoscaling" % awsSdk2Version,
       "software.amazon.awssdk" % "ec2" % awsSdk2Version,
-      "software.amazon.awssdk" % "ssm" % awsSdk2Version,
       "com.gu" %% "simple-configuration-core" % "1.5.7",
       "net.logstash.logback" % "logstash-logback-encoder" % "5.2",
       "ch.qos.logback" % "logback-core" % "1.2.7",

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ lazy val publishSettings = Seq(
     pushChanges
   )
 )
+val awsSdk2Version = "2.21.21"
 
 lazy val root = (project in file("."))
   .settings(publishSettings)
@@ -43,6 +44,9 @@ lazy val root = (project in file("."))
     scalaVersion := scala_2_12,
     name := "mobile-logstash-encoder",
     libraryDependencies ++= Seq(
+      "software.amazon.awssdk" % "autoscaling" % awsSdk2Version,
+      "software.amazon.awssdk" % "ec2" % awsSdk2Version,
+      "software.amazon.awssdk" % "ssm" % awsSdk2Version,
       "com.gu" %% "simple-configuration-core" % "1.5.7",
       "net.logstash.logback" % "logstash-logback-encoder" % "5.2",
       "ch.qos.logback" % "logback-core" % "1.2.7",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Snyk scanning detected high vulnerability in netty-https library v4.1.94, which was introduced as a transitive dependency via AWS SDK v2.

In order to fix this vulnerability, this PR bumps the AWS SDK v2 to v2.21.21 so that the fixed version of netty (v4.1.100) will be used. It also specifies the version of "software.amazon.awssdk:autoscaling", "software.amazon.awssdk:ec2" to v2.21.21 so that we use the same minor/bugfix version across all AWS SDK v2 modules.

All unit tests passed.