### PR TITLE
Fix Scala Steward by allowing building under Java 21

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import sbtrelease.ReleaseStateTransformations._
+import sbtrelease.ReleaseStateTransformations.*
 
 val scala_2_12: String = "2.12.18"
 val scala_2_13: String = "2.13.12"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.9.9

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.8-SNAPSHOT"
+ThisBuild / version := "1.1.8-SNAPSHOT"


### PR DESCRIPTION
Scala Steward can't run on this repo until it allows building under Java 21, due to https://github.com/guardian/scala-steward-public-repos/pull/67 ... we're now running our Scala Steward workflow with Java 21 LTS, which means that all projects that want to have Scala Steward updates (like this one) need to be able to build under Java 21 (even if the projects are still _running_ in production on Java 8).

Being able to build with Java 21 [requires](https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html#jdk-21-compatibility-notes) using recent versions of Scala (2.12.18+) and sbt (1.9.0+) - for this repo, all that's needed is a bump of sbt version!
