### PR TITLE
Fix actions/setup-java version comment to match pinned SHA

### DIFF
--- a/.github/workflows/sbt-dependency-graph.yaml
+++ b/.github/workflows/sbt-dependency-graph.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Install Java
         id: java
-        uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # v4.2.0
+        uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # v4.4.0
         with:
           distribution: corretto
           java-version: 17


### PR DESCRIPTION
This PR updates the actions/setup-java comment to the tag that matches the pinned SHA. When this workflow was created by Dependency Graph integrator, the version tag comment was not the correct one for the SHA.

This meant that if/when Dependabot were to bump the action to a later version, it would update the commit SHA but not the version comment as it would if they matched.

This fix ensures that the version comment and SHA are matched so that future bumps by Dependabot update both the SHA and version comment.